### PR TITLE
Show SHA256 of certs, add -z flag to mimic nc -z

### DIFF
--- a/src/tlsclient.ml
+++ b/src/tlsclient.ml
@@ -13,18 +13,18 @@ let tls_info t =
     | `Ok data -> data
     | `Error -> assert false
   in
-  let version = Tls.Printer.tls_version_to_string epoch.protocol_version
-  and cipher = Sexplib.Sexp.to_string_hum (Tls.Ciphersuite.sexp_of_ciphersuite epoch.ciphersuite)
-  and `Hex master = Hex.of_cstruct epoch.master_secret
+  let version = Tls.Printer.tls_version_to_string epoch.Tls.Core.protocol_version
+  and cipher = Sexplib.Sexp.to_string_hum (Tls.Ciphersuite.sexp_of_ciphersuite epoch.Tls.Core.ciphersuite)
+  and `Hex master = Hex.of_cstruct epoch.Tls.Core.master_secret
   and certs = List.flatten (List.map (fun x ->
       [ "subject=" ^ X509.distinguished_name_to_string (X509.subject x) ;
         "issuer=" ^ X509.distinguished_name_to_string (X509.issuer x) ])
-      epoch.peer_certificate)
+      epoch.Tls.Core.peer_certificate)
   and trust =
-    match epoch.trust_anchor with
+    match epoch.Tls.Core.trust_anchor with
     | None -> "NONE"
     | Some x -> X509.distinguished_name_to_string (X509.subject x)
-  and pubkeysize = string_of_int (match epoch.peer_certificate with
+  and pubkeysize = string_of_int (match epoch.Tls.Core.peer_certificate with
       | [] -> 0
       | x::_ -> match X509.public_key x with
         | `RSA p -> Nocrypto.Rsa.pub_bits p


### PR DESCRIPTION
This pull requests shows sha256 hashes of the certificates in the certificiate chain, shows the server timestamp, and adds an optional -z flag which immediately terminates the connection after printing the TLS debug information to the screen (similar to netcat -z).

new --help:

```
       -z, --zero-io
           zero-I/O mode [terminate after printing session info]
```

new output:

```
user@debcaml:~/tlsclient (tls_info_sha256_fp_and_option_zero-io)$ ./tlsclient.native -z github.com:443
protocol : TLS version 1.2
timestamp: 1444401420
cipher   : TLS_RSA_WITH_AES_128_CBC_SHA256
master   : 26345678909af7bb6d3204f34567890c3406d7548e7d1234567892c24567811f234555666777666666666666666614
keysize  : 2048
chain    : subject=2.5.4.15=Private Organization/1.3.6.1.4.1.311.60.2.1.3=US/1.3.6.1.4.1.311.60.2.1.2=Delaware/Serialnumber=5157550/2.5.4.9=548 4th Street/2.5.4.17=94107/C=US/SP=California/L=San Francisco/O=GitHub, Inc./CN=github.com
           issuer=C=US/O=DigiCert Inc/OU=www.digicert.com/CN=DigiCert SHA2 Extended Validation Server CA
           sha256 fingerprint: 58875244d86012b0fbd5f6c06ef16efca20e158d58e96e6f76ceda6660b59bc2
           subject=C=US/O=DigiCert Inc/OU=www.digicert.com/CN=DigiCert SHA2 Extended Validation Server CA
           issuer=C=US/O=DigiCert Inc/OU=www.digicert.com/CN=DigiCert High Assurance EV Root CA
           sha256 fingerprint: 403e062a2653059113285baf80a0d4ae422c848c9f78fad01fc94bc5b87fef1a
anchor   : NONE
```

Depends on merging of https://github.com/mirleft/ocaml-x509/pull/66 to provide the fingerprint of the certificates.
